### PR TITLE
Live schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /Manifest.toml
+
+.DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 UrlDownload = "856ac37a-3032-4c1c-9122-f86d88358c8b"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,11 @@ authors = ["Carsten Bauer <crstnbr@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+UrlDownload = "856ac37a-3032-4c1c-9122-f86d88358c8b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 

--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,10 @@ version = "0.1.0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-UrlDownload = "856ac37a-3032-4c1c-9122-f86d88358c8b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+UrlDownload = "856ac37a-3032-4c1c-9122-f86d88358c8b"
 
 [compat]
 julia = "1"

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -7,19 +7,12 @@ using JSON3
 using UrlDownload
 using PrettyTables
 
+const CONFERENCE_SCHEDULE_JSON_URL = "https://pretalx.com/juliacon2020/schedule/export/schedule.json"
+const conf_json = Ref{JSON3.Object{Vector{UInt8}, SubArray{UInt64, 1, Vector{UInt64}, Tuple{UnitRange{Int64}}, true}}}()
+
 include("countries.jl")
 include("schedule.jl")
-
-function juliacon2021()
-    if myid() == 1
-        return println(
-            "Welcome to JuliaCon 2021! Find more information on https://juliacon.org/2021/."
-        )
-    else
-        return println("Greetings from ", rand(countries), "!")
-    end
-    return nothing
-end
+include("tshirtcode.jl")
 
 function __init__()
     if isdefined(Main, :Distributed)

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -1,8 +1,12 @@
 module JuliaCon
 
 using Distributed
+using Dates: Dates, Date, DateTime, Time, Hour, Minute
+using JSON3
+using UrlDownload
 
 include("countries.jl")
+include("schedule.jl")
 
 function juliacon2021()
     if myid() == 1
@@ -38,6 +42,6 @@ function __init__()
     end
 end
 
-export juliacon2021
+export juliacon2021, schedule, now
 
 end

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -1,10 +1,11 @@
 module JuliaCon
 
-using Base: String
+using Base: String, alignment
 using Distributed
 using Dates: Dates, Date, DateTime, Time, Hour, Minute
 using JSON3
 using UrlDownload
+using PrettyTables
 
 include("countries.jl")
 include("schedule.jl")
@@ -40,6 +41,6 @@ function __init__()
     end
 end
 
-export juliacon2021, now
+export juliacon2021, now, today
 
 end

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -1,5 +1,6 @@
 module JuliaCon
 
+using Base: String
 using Distributed
 using Dates: Dates, Date, DateTime, Time, Hour, Minute
 using JSON3
@@ -29,12 +30,9 @@ function __init__()
             if myid() != 1
                 # suppress REPL warnings and "activating ..." messages
                 using Pkg, Logging
-                orig_io = Pkg.DEFAULT_IO[]
-                Pkg.DEFAULT_IO[] = IOBuffer()
                 with_logger(NullLogger()) do
-                    Pkg.REPLMode.pkgstr("activate $env")
+                    Pkg.activate(env, io=devnull)
                 end
-                Pkg.DEFAULT_IO[] = orig_io
             end
         end
         # load JuliaCon.jl on all workers
@@ -42,6 +40,6 @@ function __init__()
     end
 end
 
-export juliacon2021, schedule, now
+export juliacon2021, now
 
 end

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -118,6 +118,7 @@ end
 
 function today(; now=Dates.now(), track=nothing)
     track_schedules = get_today(; now=now)
+    isnothing(track_schedules) && return nothing
     header = (["Time", "Title", "Type"],)
     header_crayon = crayon"dark_gray bold"
     border_crayon = crayon"dark_gray"

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -1,10 +1,19 @@
 """
-Download the conference schedule as a nested JSON object.
+Get the conference schedule as a nested JSON object.
+On first call, the schedule is downloaded from Pretalx and cached for further usage.
 """
-function getschedulejson()
-    url = "https://pretalx.com/juliacon2020/schedule/export/schedule.json";
-    data = urldownload(url)
-    return data.schedule.conference
+function get_conference_json()
+    if !isassigned(conf_json)
+        data = urldownload(CONFERENCE_SCHEDULE_JSON_URL)
+        try
+            conf_json[] = data.schedule.conference
+        catch err
+            error("Invalid conference schedule JSON file.")
+            println(err)
+        end
+    end
+
+    return conf_json[]
 end
 
 """
@@ -36,8 +45,8 @@ end
 # now_fake = DateTime("2020-07-29T16:30:00.000")
 
 function get_running_talks(; now=Dates.now())
-    conf = getschedulejson()
-    days = [Date(d.date) for d in conf.days]
+    conf = get_conference_json()
+    days = Date[Date(d.date) for d in conf.days]
     
     dayidx = findfirst(isequal(Date(now)), days)
     if isnothing(dayidx)
@@ -90,7 +99,7 @@ function now(; now=Dates.now())
 end
 
 function get_today(; now=Dates.now())
-    conf = getschedulejson()
+    conf = get_conference_json()
     days = [Date(d.date) for d in conf.days]
 
     dayidx = findfirst(isequal(Date(now)), days)

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -1,0 +1,68 @@
+schedule() = println("https://pretalx.com/juliacon2021/schedule/")
+
+"""
+Download the conference schedule as a nested JSON object.
+"""
+function getschedulejson()
+    url = "https://pretalx.com/juliacon2020/schedule/export/schedule.json";
+    data = urldownload(url)
+    return data.schedule.conference
+end
+
+"""
+Given a room (i.e. a fixed day and track), it finds the talks that are running now (it only compares times).
+"""
+function _find_current_talk_in_room(room::JSON3.Array; now=Dates.now())
+    for talk in room
+        start_time = Time(talk.start)
+        dur = Time(talk.duration)
+        end_time = start_time + Hour(dur) + Minute(dur)
+        if start_time <= Time(now) <= end_time
+            return talk
+        end
+    end
+    return nothing
+end
+
+"""
+Given a fixed day, it finds the talks in all tracks / rooms that are running now (it only compares times).
+
+Returns a vector of tuples of the type `(room::Symbol, talk::JSON3.Object)`.
+"""
+function _find_current_talks_on_day(d::JSON3.Object; now=Dates.now())
+    query_result = [(r, _find_current_talk_in_room(d.rooms[r]; now=now)) for r in keys(d.rooms)]
+    return filter(x->!isnothing(x[2]), query_result)
+end
+
+
+# now_fake = DateTime("2020-07-29T16:30:00.000")
+
+function get_running_talks(; now=Dates.now())
+    conf = getschedulejson()
+    days = [Date(d.date) for d in conf.days]
+    
+    dayidx = findfirst(isequal(Date(now)), days)
+    if isnothing(dayidx)
+        @info "There is no JuliaCon program today!"
+        return nothing
+    end
+    
+    d = conf.days[dayidx]
+    if !(DateTime(d.day_start[1:end-6]) <= now <= DateTime(d.day_end[1:end-6]))
+        @info "There is no JuliaCon program now!"
+        return nothing
+    end
+    
+    current_talks = _find_current_talks_on_day(d; now=now)
+    return current_talks
+end
+
+function now(; now=Dates.now())
+    current_talks = get_running_talks(; now=now)
+    if !isnothing(current_talks)
+        for (track, talk) in current_talks
+            println(track, ": ", talk.title)
+        end
+    end
+    return nothing
+end

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -1,5 +1,3 @@
-schedule() = println("https://pretalx.com/juliacon2021/schedule/")
-
 """
 Download the conference schedule as a nested JSON object.
 """
@@ -57,12 +55,36 @@ function get_running_talks(; now=Dates.now())
     return current_talks
 end
 
+function _track2color(track::Symbol)
+    if track == Symbol("Red Track")
+        return :red
+    elseif track == Symbol("Green Track")
+        return :green
+    elseif track == Symbol("Purple Track")
+        return :magenta
+    else
+        return :default
+    end
+end
+
+function _print_running_talks(current_talks; now=Dates.now())
+    !isnothing(current_talks) || return nothing
+    # println()
+    # println(Dates.format(Dates.now(), "HH:MM dd-mm-YYYY"))
+    for (track, talk) in current_talks
+        println()
+        printstyled(track, bold=true, color=_track2color(track))
+        println()
+        println("\t", talk.title, " (", talk.type,")")
+        println("\t", "└─ ", talk.url)
+    end
+    println("\n")
+    println("(Full schedule: https://pretalx.com/juliacon2021/schedule)")
+    return nothing
+end
+
 function now(; now=Dates.now())
     current_talks = get_running_talks(; now=now)
-    if !isnothing(current_talks)
-        for (track, talk) in current_talks
-            println(track, ": ", talk.title)
-        end
-    end
+    _print_running_talks(current_talks; now=now)
     return nothing
 end

--- a/src/tshirtcode.jl
+++ b/src/tshirtcode.jl
@@ -1,0 +1,10 @@
+function juliacon2021()
+    if myid() == 1
+        return println(
+            "Welcome to JuliaCon 2021! Find more information on https://juliacon.org/2021/."
+        )
+    else
+        return println("Greetings from ", rand(countries), "!")
+    end
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using JuliaCon
 using Test
 using Distributed
+import Dates
+
+fakenow = Dates.DateTime("2020-07-29T16:30:00.000") # JuliaCon2020
 
 @testset "JuliaCon.jl" begin
     @testset "juliacon2021()" begin
@@ -14,5 +17,13 @@ using Distributed
             @test isnothing(@everywhere juliacon2021())
             rmprocs(workers())
         end
+    end
+
+    @testset "Schedule" begin
+        @test isnothing(JuliaCon.now())
+        @test isnothing(JuliaCon.now(; now=fakenow))
+        @test isnothing(JuliaCon.today())
+        @test isnothing(JuliaCon.today(; now=fakenow))
+        @test isnothing(JuliaCon.today(; now=fakenow, track="BoF"))
     end
 end


### PR DESCRIPTION
Live schedule alpha. Currently testing it for the JuliaCon 2020 schedule (because the new one isn't online yet).

<img width="1222" alt="Screenshot 2021-05-31 at 13 46 12" src="https://user-images.githubusercontent.com/187980/120188564-92a09a80-c216-11eb-9a4b-5c5863061b5e.png">

**Ideas / Todo:**
* [x] Download schedule only once (on pkg load?)
* [x] Pretty printing

Based on #4.