### PR TITLE
Add a dispatch option to now, today, and juliacon2021

### DIFF
--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -146,11 +146,31 @@ function _print_running_talks(current_talks; now=default_now())
     return nothing
 end
 
-function now(; now=default_now())
+function now(::Val{:text}; now)
+    current_talks = get_running_talks(; now=now)
+    str = ""
+    if !isnothing(current_talks)
+        for (track, talk) in current_talks
+            str *= """
+            $track
+            \t$(talk.title) ($(talk.type))
+            \t├─ $(JuliaCon.speakers2str(talk.speaker))
+            \t└─ $(talk.url)
+            """
+        end
+    end
+    str *= "\n(Full schedule: https://pretalx.com/juliacon2021/schedule)"
+    return str
+end
+
+function now(::Val{:terminal}; now)
     current_talks = get_running_talks(; now=now)
     _print_running_talks(current_talks; now=now)
     return nothing
 end
+
+# A dispatcher for the `now` methods. Default to terminal output.
+now(; now=default_now(), output=:terminal) = JuliaCon.now(Val(output); now=now)
 
 function get_today(; now=default_now())
     jcon = get_conference_schedule()
@@ -167,36 +187,41 @@ end
 
 speakers2str(speaker::Vector{String}) = join(speaker, ", ")
 
-function today(; now=default_now(), track=nothing, terminal_links=TERMINAL_LINKS)
-    track_schedules = get_today(; now=now)
-    isnothing(track_schedules) && return nothing
-    header = (["Time", "Title", "Type", "Speaker"],)
-    header_crayon = crayon"dark_gray bold"
-    border_crayon = crayon"dark_gray"
-    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
-    for (tr, talks) in track_schedules
-        !isnothing(track) && tr != track && continue
-        h_current = _get_current_talk_highlighter(talks; now=now)
-        println()
-        data = Matrix{Union{String, URLTextCell}}(undef, length(talks), 4)
-        for (i, talk) in enumerate(talks)
-            data[i, 1] = talk.start
-            data[i, 2] = terminal_links ? URLTextCell(talk.title, talk.url) : talk.title
-            data[i, 3] = abbrev(talk.type)
-            data[i, 4] = speakers2str(talk.speaker)
-        end
-        pretty_table(
-            data;
-            title=tr,
-            title_crayon=Crayon(; foreground=_track2color(tr), bold=true),
-            header=header,
-            header_crayon=header_crayon,
-            border_crayon=border_crayon,
-            highlighters=(h_times, h_current),
-            tf=tf_unicode_rounded,
-            alignment=[:c, :l, :c, :l],
-        )
-    end
+function today_tables_output(
+    data, tr, header, header_crayon, border_crayon, h_times, h_current, ::Val{:terminal}
+)
+    pretty_table(
+        data;
+        title=tr,
+        title_crayon=Crayon(; foreground=_track2color(tr), bold=true),
+        header=header,
+        header_crayon=header_crayon,
+        border_crayon=border_crayon,
+        highlighters=(h_times, h_current),
+        tf=tf_unicode_rounded,
+        alignment=[:c, :l, :c, :l],
+    )
+    return nothing
+end
+
+function today_tables_output(
+    data, tr, header, header_crayon, border_crayon, h_times, h_current, ::Val{:text}
+)
+    return pretty_table(
+        String,
+        data;
+        title=tr,
+        title_crayon=Crayon(; foreground=_track2color(tr), bold=true),
+        header=header,
+        header_crayon=header_crayon,
+        border_crayon=border_crayon,
+        highlighters=(h_times, h_current),
+        tf=tf_unicode_rounded,
+        alignment=[:c, :l, :c, :l],
+    )
+end
+
+function today_legend(::Val{:terminal})
     println()
     printstyled("Currently running talks are highlighted in ")
     printstyled("yellow"; color=:yellow)
@@ -212,6 +237,65 @@ function today(; now=default_now(), track=nothing, terminal_links=TERMINAL_LINKS
     println(abbrev(BoF), " = Birds of Feather")
     println()
     println("Check out https://pretalx.com/juliacon2021/schedule for more information.")
+    return nothing
+end
+
+function today_legend(::Val{:text})
+    legend = """
+    Currently running talks are highlighted in yellow (or not cause WIP).
+
+    $(JuliaCon.abbrev(JuliaCon.Talk)) = Talk, $(JuliaCon.abbrev(JuliaCon.LightningTalk)) = Lightning Talk, $(JuliaCon.abbrev(JuliaCon.SponsorTalk)) = Sponsor Talk, $(JuliaCon.abbrev(JuliaCon.Keynote)) = Keynote,
+    $(JuliaCon.abbrev(JuliaCon.Workshop)) = Workshop, $(JuliaCon.abbrev(JuliaCon.Minisymposia)) = Minisymposia, $(JuliaCon.abbrev(JuliaCon.BoF)) = Birds of Feather
+
+    Check out https://pretalx.com/juliacon2021/schedule for more information.
+    """
+    return legend
+end
+
+# A dispatcher for the `today` methods. Default to terminal output.
+function today(;
+    now=default_now(),
+    track=nothing,
+    terminal_links=TERMINAL_LINKS,
+    output=:terminal, # can take the :text value to output a Vector{String}
+)
+    track_schedules = get_today(; now=now)
+    isnothing(track_schedules) && return nothing
+    header = (["Time", "Title", "Type", "Speaker"],)
+    header_crayon = crayon"dark_gray bold"
+    border_crayon = crayon"dark_gray"
+    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
+
+    strings = Vector{String}()
+    header = (["Time", "Title", "Type", "Speaker"],)
+    for (tr, talks) in track_schedules
+        !isnothing(track) && tr != track && continue
+        h_current = _get_current_talk_highlighter(talks; now=now)
+        data = Matrix{Union{String,URLTextCell}}(undef, length(talks), 4)
+        for (i, talk) in enumerate(talks)
+            data[i, 1] = talk.start
+            data[i, 2] = terminal_links ? URLTextCell(talk.title, talk.url) : talk.title
+            data[i, 3] = JuliaCon.abbrev(talk.type)
+            data[i, 4] = JuliaCon.speakers2str(talk.speaker)
+        end
+        string_or_nothing = today_tables_output(
+            data,
+            tr,
+            header,
+            header_crayon,
+            border_crayon,
+            h_times,
+            h_current,
+            Val(output),
+        )
+        isnothing(string_or_nothing) || push!(strings, string_or_nothing)
+    end
+
+    string_or_nothing = today_legend(Val(output))
+    if !isnothing(string_or_nothing)
+        push!(strings, string_or_nothing)
+        return strings
+    end
     return nothing
 end
 

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -187,41 +187,85 @@ end
 
 speakers2str(speaker::Vector{String}) = join(speaker, ", ")
 
-function today_tables_output(
-    data, tr, header, header_crayon, border_crayon, h_times, h_current, ::Val{:terminal}
-)
-    pretty_table(
-        data;
-        title=tr,
-        title_crayon=Crayon(; foreground=_track2color(tr), bold=true),
-        header=header,
-        header_crayon=header_crayon,
-        border_crayon=border_crayon,
-        highlighters=(h_times, h_current),
-        tf=tf_unicode_rounded,
-        alignment=[:c, :l, :c, :l],
-    )
+function _get_current_talk_highlighter(talks; now=default_now())
+    for (i, talk) in enumerate(talks)
+        start_time = Time(talk.start)
+        dur = Time(talk.duration)
+        end_time = start_time + Hour(dur) + Minute(dur)
+        if start_time <= Time(now) <= end_time
+            return Highlighter((data, m, n) -> m == i, crayon"yellow")
+        end
+    end
     return nothing
 end
 
-function today_tables_output(
-    data, tr, header, header_crayon, border_crayon, h_times, h_current, ::Val{:text}
+function _get_today_tables(;
+    now=default_now(), track=nothing, terminal_links=TERMINAL_LINKS
 )
-    return pretty_table(
-        String,
-        data;
-        title=tr,
-        title_crayon=Crayon(; foreground=_track2color(tr), bold=true),
-        header=header,
-        header_crayon=header_crayon,
-        border_crayon=border_crayon,
-        highlighters=(h_times, h_current),
-        tf=tf_unicode_rounded,
-        alignment=[:c, :l, :c, :l],
-    )
+    track_schedules = get_today(; now=now)
+    isnothing(track_schedules) && return (nothing, nothing, nothing)
+
+    tracks = String[]
+    tables = Matrix{Union{String,URLTextCell}}[]
+    highlighters = Union{Nothing,Highlighter}[]
+    for (tr, talks) in track_schedules
+        !isnothing(track) && tr != track && continue
+        push!(tracks, tr)
+
+        data = Matrix{Union{String,URLTextCell}}(undef, length(talks), 4)
+        for (i, talk) in enumerate(talks)
+            data[i, 1] = talk.start
+            data[i, 2] = terminal_links ? URLTextCell(talk.title, talk.url) : talk.title
+            data[i, 3] = JuliaCon.abbrev(talk.type)
+            data[i, 4] = JuliaCon.speakers2str(talk.speaker)
+        end
+        push!(tables, data)
+
+        h_current = _get_current_talk_highlighter(talks; now=now)
+        push!(highlighters, h_current)
+    end
+
+    @assert length(tables) == length(highlighters) == length(tracks)
+    return (tracks, tables, highlighters)
 end
 
-function today_legend(::Val{:terminal})
+# A dispatcher for the `today` methods. Defaults to terminal output.
+function today(;
+    now=default_now(),
+    track=nothing,
+    terminal_links=TERMINAL_LINKS,
+    output=:terminal, # can take the :text value to output a Vector{String}
+)
+    return today(Val(output); now, track, terminal_links)
+end
+
+function today(::Val{:terminal}; now, track, terminal_links)
+    tracks, tables, highlighters = _get_today_tables(; now, track, terminal_links)
+    isnothing(tables) && return nothing
+
+    header = (["Time", "Title", "Type", "Speaker"],)
+    header_crayon = crayon"dark_gray bold"
+    border_crayon = crayon"dark_gray"
+    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
+
+    for j in eachindex(tracks)
+        track = tracks[j]
+        data = tables[j]
+        h_current = highlighters[j]
+        println()
+        pretty_table(
+            data;
+            title=track,
+            title_crayon=Crayon(; foreground=_track2color(track), bold=true),
+            header=header,
+            header_crayon=header_crayon,
+            border_crayon=border_crayon,
+            highlighters=(h_times, h_current),
+            tf=tf_unicode_rounded,
+            alignment=[:c, :l, :c, :l],
+        )
+    end
+
     println()
     printstyled("Currently running talks are highlighted in ")
     printstyled("yellow"; color=:yellow)
@@ -240,7 +284,35 @@ function today_legend(::Val{:terminal})
     return nothing
 end
 
-function today_legend(::Val{:text})
+function today(::Val{:text}; now, track, terminal_links)
+    tracks, tables, highlighters = _get_today_tables(; now, track, terminal_links)
+    isnothing(tables) && return nothing
+
+    header = (["Time", "Title", "Type", "Speaker"],)
+    header_crayon = crayon"dark_gray bold"
+    border_crayon = crayon"dark_gray"
+    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
+
+    strings = Vector{String}()
+    for j in eachindex(tracks)
+        track = tracks[j]
+        data = tables[j]
+        h_current = highlighters[j]
+        str = pretty_table(
+            String,
+            data;
+            title=track,
+            title_crayon=Crayon(; foreground=_track2color(track), bold=true),
+            header=header,
+            header_crayon=header_crayon,
+            border_crayon=border_crayon,
+            highlighters=(h_times, h_current),
+            tf=tf_unicode_rounded,
+            alignment=[:c, :l, :c, :l],
+        )
+        push!(strings, str)
+    end
+
     legend = """
     Currently running talks are highlighted in yellow (or not cause WIP).
 
@@ -249,64 +321,6 @@ function today_legend(::Val{:text})
 
     Check out https://pretalx.com/juliacon2021/schedule for more information.
     """
-    return legend
-end
-
-# A dispatcher for the `today` methods. Default to terminal output.
-function today(;
-    now=default_now(),
-    track=nothing,
-    terminal_links=TERMINAL_LINKS,
-    output=:terminal, # can take the :text value to output a Vector{String}
-)
-    track_schedules = get_today(; now=now)
-    isnothing(track_schedules) && return nothing
-    header = (["Time", "Title", "Type", "Speaker"],)
-    header_crayon = crayon"dark_gray bold"
-    border_crayon = crayon"dark_gray"
-    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
-
-    strings = Vector{String}()
-    header = (["Time", "Title", "Type", "Speaker"],)
-    for (tr, talks) in track_schedules
-        !isnothing(track) && tr != track && continue
-        h_current = _get_current_talk_highlighter(talks; now=now)
-        data = Matrix{Union{String,URLTextCell}}(undef, length(talks), 4)
-        for (i, talk) in enumerate(talks)
-            data[i, 1] = talk.start
-            data[i, 2] = terminal_links ? URLTextCell(talk.title, talk.url) : talk.title
-            data[i, 3] = JuliaCon.abbrev(talk.type)
-            data[i, 4] = JuliaCon.speakers2str(talk.speaker)
-        end
-        string_or_nothing = today_tables_output(
-            data,
-            tr,
-            header,
-            header_crayon,
-            border_crayon,
-            h_times,
-            h_current,
-            Val(output),
-        )
-        isnothing(string_or_nothing) || push!(strings, string_or_nothing)
-    end
-
-    string_or_nothing = today_legend(Val(output))
-    if !isnothing(string_or_nothing)
-        push!(strings, string_or_nothing)
-        return strings
-    end
-    return nothing
-end
-
-function _get_current_talk_highlighter(talks; now=default_now())
-    for (i, talk) in enumerate(talks)
-        start_time = Time(talk.start)
-        dur = Time(talk.duration)
-        end_time = start_time + Hour(dur) + Minute(dur)
-        if start_time <= Time(now) <= end_time
-            return Highlighter((data, m, n) -> m == i, crayon"yellow")
-        end
-    end
-    return nothing
+    push!(strings, legend)
+    return strings
 end

--- a/src/tshirtcode.jl
+++ b/src/tshirtcode.jl
@@ -1,4 +1,4 @@
-function juliacon2021()
+function juliacon2021(::Val{:terminal})
     if myid() == 1
         return println(
             "Welcome to JuliaCon 2021! Find more information on https://juliacon.org/2021/."
@@ -8,3 +8,10 @@ function juliacon2021()
     end
     return nothing
 end
+
+# TODO: needs love for a distributed version based on the :terminal method (no hurry though)
+function juliacon2021(::Val{:text})
+    return "Welcome to JuliaCon 2021! Find more information on https://juliacon.org/2021/."
+end
+
+juliacon2021(; output=:terminal) = juliacon2021(Val(output))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ import Dates
             rmprocs(workers())
         end
     end
-    
+
     @testset "Preferences" begin
         @testset "Debug mode" begin
             fakenow = Dates.DateTime("2020-07-29T16:30:00.000")
@@ -46,12 +46,31 @@ import Dates
         @test isassigned(JuliaCon.jcon)
 
         JuliaCon.debugmode()
+
+        # output to terminal
+        println("\n")
+        @info "Testing output to terminal"
         @test isnothing(JuliaCon.now())
         @test isnothing(JuliaCon.now())
         @test isnothing(JuliaCon.today())
         @test isnothing(JuliaCon.today())
         @test isnothing(JuliaCon.today(track="BoF"))
         @test isnothing(JuliaCon.today(terminal_links=true))
+
+        # output to text (Vector{Sting})
+        println("\n")
+        @info "Testing output to text, i.e. string(s)"
+
+        ## Print output
+        foreach(println, JuliaCon.today(output = :text))
+        println(JuliaCon.now(output = :text))
+        println(juliacon2021(output = :text))
+
+        ## Test output types
+        @test eltype(JuliaCon.today(output = :text)) == String
+        @test typeof(JuliaCon.now(output = :text)) == String
+        @test typeof(juliacon2021(output = :text)) == String
+
         JuliaCon.debugmode(false)
     end
 


### PR DESCRIPTION
Add a dispatch option to now, today, and juliacon2021 to return a string instead of printing in the terminal

The behavior of those 3 functions is not changing unless we call them with the keyword arg `output=:text`
So no breaking changes!

The goal of this PR is to have JuliaCon.jl be usable by external packages such as the chatbot HoJBot.jl that we are developing there: https://github.com/Humans-of-Julia/HoJBot.jl
As we would like to have the bot running before the incoming JuliaCon, it would be nice to have the PR merged quickly and a new version tag!

EDIT: I could probably recycle some part of the code for `today` ... but it can be done in another PR