### PR TITLE
Proposal to include `speaker` into `conference_schedule`

### DIFF
--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -14,6 +14,7 @@ using DataFrames
 include("preferences.jl")
 include("countries.jl")
 include("tshirtcode.jl")
+include("formatting.jl")
 include("schedule.jl")
 
 function __init__()

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -1,0 +1,91 @@
+"""
+    pretty_print_results
+
+Print the results of functions like `today`.
+"""
+function pretty_print_results(now, tracks, legend, highlighting, tables, highlighters)
+    header = (["Time", "Title", "Type", "Speaker"],)
+    header_crayon = crayon"dark_gray bold"
+    border_crayon = crayon"dark_gray"
+    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
+
+    println()
+    println(Dates.format(TimeZones.Date(now), "E d U Y"))
+
+    for j in eachindex(tracks)
+        track = tracks[j]
+        data = tables[j]
+        h_running = highlighters[j]
+        println()
+        pretty_table(
+            data;
+            title=track,
+            title_crayon=Crayon(; foreground=_track2color(track), bold=true),
+            header=header,
+            header_crayon=header_crayon,
+            border_crayon=border_crayon,
+            highlighters=(h_times, h_running),
+            tf=tf_unicode_rounded,
+            alignment=[:c, :l, :c, :l],
+        )
+    end
+
+    if legend 
+        print_legend(highlighting)
+    end
+
+    return nothing
+end
+
+
+"""
+    results_to_string 
+
+Put the results of functions like `today` to a string.
+"""
+function results_to_string(now, tracks, legend, highlighting, tables, highlighters)
+    header = (["Time", "Title", "Type", "Speaker"],)
+    header_crayon = crayon"dark_gray bold"
+    border_crayon = crayon"dark_gray"
+    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
+
+    strings = Vector{String}()
+    push!(strings, string(Dates.format(TimeZones.Date(now), "E d U Y")))
+    for j in eachindex(tracks)
+        track = tracks[j]
+        data = tables[j]
+        h_running = highlighters[j]
+        str = pretty_table(
+            String,
+            data;
+            title=track,
+            title_crayon=Crayon(; foreground=_track2color(track), bold=true),
+            header=header,
+            header_crayon=header_crayon,
+            border_crayon=border_crayon,
+            highlighters=(h_times, h_running),
+            tf=tf_unicode_rounded,
+            alignment=[:c, :l, :c, :l],
+        )
+        push!(strings, str)
+    end
+
+    legend = if highlighting
+        """
+        Currently running talks are prefixed by a '>'.
+
+        """
+    else
+        ""
+    end
+
+    legend *= """
+    $(JuliaCon.abbrev(JuliaCon.Talk)) = Talk, $(JuliaCon.abbrev(JuliaCon.LightningTalk)) = Lightning Talk, $(JuliaCon.abbrev(JuliaCon.SponsorTalk)) = Sponsor Talk, $(JuliaCon.abbrev(JuliaCon.Keynote)) = Keynote,
+    $(JuliaCon.abbrev(JuliaCon.Workshop)) = Workshop, $(JuliaCon.abbrev(JuliaCon.Minisymposium)) = Minisymposium, $(JuliaCon.abbrev(JuliaCon.BoF)) = Birds of Feather,
+    $(JuliaCon.abbrev(JuliaCon.Experience)) = Experience, $(JuliaCon.abbrev(JuliaCon.VirtualPoster)) = Virtual Poster
+
+    Check out $(CONFERENCE_SCHEDULE_URL) for more information.
+    """
+    push!(strings, legend)
+    return strings
+end

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -373,87 +373,19 @@ function today(::Val{:terminal}; now, speaker, track, terminal_links, highlighti
     tracks, tables, highlighters = _get_today_tables(; now, speaker, track, terminal_links, highlighting)
     isnothing(tables) && return nothing
 
-    header = (["Time", "Title", "Type", "Speaker"],)
-    header_crayon = crayon"dark_gray bold"
-    border_crayon = crayon"dark_gray"
-    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
-
-    println()
-    println(Dates.format(TimeZones.Date(now), "E d U Y"))
-
-    for j in eachindex(tracks)
-        track = tracks[j]
-        data = tables[j]
-        h_running = highlighters[j]
-        println()
-        pretty_table(
-            data;
-            title=track,
-            title_crayon=Crayon(; foreground=_track2color(track), bold=true),
-            header=header,
-            header_crayon=header_crayon,
-            border_crayon=border_crayon,
-            highlighters=(h_times, h_running),
-            tf=tf_unicode_rounded,
-            alignment=[:c, :l, :c, :l],
-        )
-    end
-
-    if legend 
-        print_legend(highlighting)
-    end
+    pretty_print_results(now, tracks, legend, highlighting, tables, highlighters)
     return nothing
 end
+
+
 
 function today(::Val{:text}; now, speaker, track, terminal_links, highlighting=true, legend=true)
     tracks, tables, highlighters = _get_today_tables(; now, speaker, track, terminal_links, highlighting, text_highlighting=highlighting)
     isnothing(tables) && return nothing
 
-    header = (["Time", "Title", "Type", "Speaker"],)
-    header_crayon = crayon"dark_gray bold"
-    border_crayon = crayon"dark_gray"
-    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
-
-    strings = Vector{String}()
-    push!(strings, string(Dates.format(TimeZones.Date(now), "E d U Y")))
-    for j in eachindex(tracks)
-        track = tracks[j]
-        data = tables[j]
-        h_running = highlighters[j]
-        str = pretty_table(
-            String,
-            data;
-            title=track,
-            title_crayon=Crayon(; foreground=_track2color(track), bold=true),
-            header=header,
-            header_crayon=header_crayon,
-            border_crayon=border_crayon,
-            highlighters=(h_times, h_running),
-            tf=tf_unicode_rounded,
-            alignment=[:c, :l, :c, :l],
-        )
-        push!(strings, str)
-    end
-
-    legend = if highlighting
-        """
-        Currently running talks are prefixed by a '>'.
-
-        """
-    else
-        ""
-    end
-
-    legend *= """
-    $(JuliaCon.abbrev(JuliaCon.Talk)) = Talk, $(JuliaCon.abbrev(JuliaCon.LightningTalk)) = Lightning Talk, $(JuliaCon.abbrev(JuliaCon.SponsorTalk)) = Sponsor Talk, $(JuliaCon.abbrev(JuliaCon.Keynote)) = Keynote,
-    $(JuliaCon.abbrev(JuliaCon.Workshop)) = Workshop, $(JuliaCon.abbrev(JuliaCon.Minisymposium)) = Minisymposium, $(JuliaCon.abbrev(JuliaCon.BoF)) = Birds of Feather,
-    $(JuliaCon.abbrev(JuliaCon.Experience)) = Experience, $(JuliaCon.abbrev(JuliaCon.VirtualPoster)) = Virtual Poster
-
-    Check out $(CONFERENCE_SCHEDULE_URL) for more information.
-    """
-    push!(strings, legend)
-    return strings
+    results_to_string(now, tracks, legend, highlighting, tables, highlighters)
 end
+
 
 """     tomorrow(; speaker)
 
@@ -485,10 +417,12 @@ function talks_by(speaker; legend=false)
 
     # list of ZoneDateTime for all JuliaCon days
     all_juliacon_dates = map(d -> ZonedDateTime(d..., JuliaCon.LOCAL_TIMEZONE), days)
-    t(d, legend) = today(; now = d, speaker, legend)
+    t(d, legend) = _get_today_tables(; now = d, speaker, legend)
 
     for d in all_juliacon_dates
-        t(d, legend)
+        tracks, tables, highlighters = _get_today_tables(; now=d, speaker)
+        isnothing(tables) && continue
+        pretty_print_results(d, tracks, legend, true, tables, highlighters)
     end
 
     return nothing

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -405,7 +405,7 @@ function today(::Val{:terminal}; now, speaker, track, terminal_links, highlighti
     return nothing
 end
 
-function today(::Val{:text}; now, speaker, track, terminal_links, highlighting=true)
+function today(::Val{:text}; now, speaker, track, terminal_links, highlighting=true, legend=true)
     tracks, tables, highlighters = _get_today_tables(; now, speaker, track, terminal_links, highlighting, text_highlighting=highlighting)
     isnothing(tables) && return nothing
 

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -385,59 +385,7 @@ function today(::Val{:terminal}; now, speaker, track, terminal_links, highlighti
     tracks, tables, highlighters = _get_today_tables(; now, speaker, track, terminal_links, highlighting)
     isnothing(tables) && return nothing
 
-<<<<<<< HEAD
     pretty_print_results(now, tracks, legend, highlighting, tables, highlighters)
-    return nothing
-end
-
-
-=======
-    header = (["Time", "Title", "Type", "Speaker"],)
-    header_crayon = crayon"dark_gray bold"
-    border_crayon = crayon"dark_gray"
-    h_times = Highlighter((data, i, j) -> j == 1, crayon"white bold")
-
-    println()
-    println(Dates.format(TimeZones.Date(now), "E d U Y"))
-
-    for j in eachindex(tracks)
-        track = tracks[j]
-        data = tables[j]
-        h_running = highlighters[j]
-        println()
-        pretty_table(
-            data;
-            title=_add_track_emoji(track),
-            title_crayon=Crayon(; foreground=_track2color(track), bold=true),
-            header=header,
-            header_crayon=header_crayon,
-            border_crayon=border_crayon,
-            highlighters=(h_times, h_running),
-            tf=tf_unicode_rounded,
-            alignment=[:c, :l, :c, :l],
-        )
-    end
-
-    println()
-    if highlighting
-        printstyled("Currently running talks are highlighted in ")
-        printstyled("yellow"; color=:yellow)
-        printstyled(".")
-        println()
-        println()
-    end
-    print(abbrev(Talk), " = Talk, ")
-    print(abbrev(LightningTalk), " = Lightning Talk, ")
-    print(abbrev(SponsorTalk), " = Sponsor Talk, ")
-    println(abbrev(Keynote), " = Keynote, ")
-    print(abbrev(Workshop), " = Workshop, ")
-    print(abbrev(Minisymposium), " = Minisymposium, ")
-    println(abbrev(BoF), " = Birds of Feather, ")
-    print(abbrev(Experience), " = Experience, ")
-    print(abbrev(VirtualPoster), " = Virtual Poster, ")
-    println(abbrev(SocialHour), " = Social Hour")
-    println()
-    println("Check out $(CONFERENCE_SCHEDULE_URL) for more information.")
     return nothing
 end
 

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -399,7 +399,7 @@ function tomorrow(;
     track=nothing,
     terminal_links=TERMINAL_LINKS,
     output=:terminal, # can take the :text value to output a Vector{String},
-    legend=false
+    legend=true
 )
     return today(Val(output); now = now + Dates.Day(1), speaker, track, terminal_links, highlighting = false,
                  legend)

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -406,11 +406,11 @@ function tomorrow(;
 end
 
 """
-    talks_by(speaker)
+    talks_by(speaker; output=:terminal, legend=false)
 
 Prints all talks of a speaker identified by the (sub-)string `speaker`
 """
-function talks_by(speaker; legend=false)
+function talks_by(speaker; output=:terminal, legend=false)
     df = get_conference_schedule()
     # strip of time and filter for pure days
     days = unique(map(x -> Dates.yearmonthday(x), df.start))
@@ -419,11 +419,25 @@ function talks_by(speaker; legend=false)
     all_juliacon_dates = map(d -> ZonedDateTime(d..., JuliaCon.LOCAL_TIMEZONE), days)
     t(d, legend) = _get_today_tables(; now = d, speaker, legend)
 
+    _print_talks_by(all_juliacon_dates, speaker, legend, Val(output))
+end
+
+function _print_talks_by(all_juliacon_dates, speaker, legend, ::Val{:text})
+    str = []
+    for d in all_juliacon_dates
+        tracks, tables, highlighters = _get_today_tables(; now=d, speaker)
+        isnothing(tables) && continue
+        s = results_to_string(d, tracks, legend, true, tables, highlighters)
+        append!(str, s)
+    end
+    return str
+end
+
+function _print_talks_by(all_juliacon_dates, speaker, legend, ::Val{:terminal})
     for d in all_juliacon_dates
         tracks, tables, highlighters = _get_today_tables(; now=d, speaker)
         isnothing(tables) && continue
         pretty_print_results(d, tracks, legend, true, tables, highlighters)
     end
-
     return nothing
 end

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -143,7 +143,7 @@ On first call, the schedule is downloaded from Pretalx and cached for further us
 function get_conference_schedule(; speaker=nothing)
     isassigned(jcon) || update_schedule()
     # filter for speaker
-    jcon_filt = filter(jcon[]; view=true) do talk
+    jcon_filt = filter(jcon[]) do talk
         return isnothing(speaker) || any(contains.(talk.speaker, speaker))
     end
     return jcon_filt

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -313,6 +313,11 @@ function _get_today_tables(;
 end
 
 # A dispatcher for the `today` methods. Defaults to terminal output.
+"""     today(; speaker)
+
+Prints the schedule of today.
+`speaker` can be a string identifying the speaker to filter the schedule.
+"""
 function today(;
     now=default_now(),
     speaker=nothing,
@@ -426,6 +431,11 @@ function today(::Val{:text}; now, speaker, track, terminal_links, highlighting=t
     return strings
 end
 
+"""     tomorrow(; speaker)
+
+Prints the schedule of tomorrow.
+`speaker` can be a string identifying the speaker to filter the schedule.
+"""
 function tomorrow(;
     now=default_now(),
     speaker=nothing,

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -96,11 +96,21 @@ abbrev(x::JuliaConTalkType) = abbrev(typeof(x))
 is_schedule_json_available() = isfile(joinpath(CACHE_DIR, "schedule.json"))
 
 """
+    get_all_tracks()
+
+Returns a list of strings containing all track names.
+"""
+function get_tracks()
+    cs = get_conference_schedule()
+    return unique(cs.track)
+end
+
+"""
     get_conference_schedule(; speaker=nothing)
 
 Get the conference schedule as a DataFrame.
 On first call, the schedule is downloaded from Pretalx and cached for further usage.
-`speaker` can be a name or a string identifying the speaker to filter the schedule.
+`speaker` can be a string identifying the speaker to filter the schedule.
 """
 function get_conference_schedule(; speaker=nothing)
     isassigned(jcon) || update_schedule()
@@ -317,6 +327,7 @@ end
 
 Prints the schedule of today.
 `speaker` can be a string identifying the speaker to filter the schedule.
+`track` can be string used to filter for a track. See `JuliaCon.get_tracks()` for possible options.
 """
 function today(;
     now=default_now(),
@@ -435,6 +446,7 @@ end
 
 Prints the schedule of tomorrow.
 `speaker` can be a string identifying the speaker to filter the schedule.
+`track` can be string used to filter for a track. See `JuliaCon.get_tracks()` for possible options.
 """
 function tomorrow(;
     now=default_now(),


### PR DESCRIPTION
Hey,

as discussed in #25 here a proposal to include a filter for `speaker`.

Unfortunately, the pretty printing seems to be hard coded into `today` which makes it hard to easily add the functionality.

Therefore, I thought it would be OK to include that into the raw `get_conference_schedule`:
```julia
julia> JuliaCon.today(speaker="Felix")

Wednesday 28 July 2021

Purple
╭───────┬────────────────────────────────────────────────┬──────┬────────────────╮
│ Time  │ Title                                          │ Type │ Speaker        │
├───────┼────────────────────────────────────────────────┼──────┼────────────────┤
│ 19:10 │ DeconvOptim.jl: Microscopy Image Deconvolution │  L   │ Felix Wechsler │
╰───────┴────────────────────────────────────────────────┴──────┴────────────────╯

Currently running talks are highlighted in yellow.

T = Talk, L = Lightning Talk, S = Sponsor Talk, K = Keynote, 
W = Workshop, M = Minisymposium, BoF = Birds of Feather, 
E = Experience, P = Virtual Poster

Check out https://live.juliacon.org/agenda for more information.

julia> JuliaCon.tomorrow(speaker="Carsten")

Thursday 29 July 2021

BoF/Mini Track
╭───────┬─────────────────────────────────────┬──────┬────────────────────────────────────────────────────────────────
│ Time  │ Title                               │ Type │ Speaker                                                       ⋯
├───────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────
│ 18:30 │ Julia in High-Performance Computing │ BoF  │ Valentin Churavy, Michael Schlottke-Lakemper, Simon Byrne et  ⋯
╰───────┴─────────────────────────────────────┴──────┴────────────────────────────────────────────────────────────────
                                                                                                      1 column omitted

T = Talk, L = Lightning Talk, S = Sponsor Talk, K = Keynote, 
W = Workshop, M = Minisymposium, BoF = Birds of Feather, 
E = Experience, P = Virtual Poster

Check out https://live.juliacon.org/agenda for more information.

julia> JuliaCon.get_conference_schedule(speaker="Felix")
4×7 SubDataFrame
 Row │ start                      duration    title                              speaker                           
     │ ZonedDat…                  Compound…   String                             Array…                            
─────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ 2021-07-28T17:10:00+00:00  10 minutes  DeconvOptim.jl: Microscopy Image…  ["Felix Wechsler"]
   2 │ 2021-07-29T16:30:00+00:00  30 minutes  InvertibleNetworks.jl - Memory e…  ["Philipp A. Witte", "Mathias Lo…
   3 │ 2021-07-30T19:30:00+00:00  10 minutes  FourierTools.jl | Working with t…  ["Rainer Heintzmann", "Felix Wec…
   4 │ 2021-07-30T17:15:00+00:00  3 minutes   IndexFunArrays.jl | Fun with ind…  ["Felix Wechsler", "Rainer Heint…
                                                                                                     3 columns omitted
```

Is that something you like? 

Cheers,

Felix