### PR TITLE
Allow legacy timezone

### DIFF
--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -41,7 +41,7 @@ function set_terminallinks(on::Bool)
     )
 end
 function set_local_timezone(tz::AbstractString)
-    if !istimezone(tz)
+    if !istimezone(tz, TimeZones.Class(:DEFAULT) | TimeZones.Class(:LEGACY))
         throw(ArgumentError("\"$tz\" isn't a valid timezone. Check out TimeZones.timezone_names() for possible options."))
     else
         @set_preferences!("local_timezone" => tz)


### PR DESCRIPTION
My `localzone()` shows `Europe/Kiev` that is a legacy name for `Europe/Kyiv`.

```
julia> localzone()
Europe/Kiev (UTC+2/UTC+3)

julia> istimezone(string(localzone()))
false

julia> istimezone("Europe/Kyiv")
true

julia> istimezone("Europe/Kiev")
false

julia> istimezone(string(localzone()), TimeZones.Class(:DEFAULT) | TimeZones.Class(:LEGACY))
true
```