### PR TITLE
Add Precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,18 +11,20 @@ Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
+DataFrames = "1.0"
 JSON = "0.21"
+PrecompileTools = "1"
 Preferences = "1.2"
 PrettyTables = "2"
 TimeZones = "1.5"
 TimerOutputs = "0.5"
-DataFrames = "1.0"
 julia = "1.6"
 
 [extras]

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -45,11 +45,9 @@ end
         JuliaCon.tomorrow()
         JuliaCon.now()
         JuliaCon.talksby("Carsten Bauer")
+        JuliaCon.jcon[] = nothing
     end
 end
-
-
-
 
 export juliacon2024
 

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -40,8 +40,12 @@ end
 
 
 @compile_workload begin
-    JuliaCon.today()
-    JuliaCon.talksby("Carsten Bauer")
+    redirect_stdout(Pipe()) do
+        JuliaCon.today()
+        JuliaCon.tomorrow()
+        JuliaCon.now()
+        JuliaCon.talksby("Carsten Bauer")
+    end
 end
 
 

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -40,7 +40,7 @@ end
 
 
 @compile_workload begin
-    redirect_stdout(Pipe()) do
+    redirect_stdout(Base.DevNull()) do
         JuliaCon.today()
         JuliaCon.tomorrow()
         JuliaCon.now()

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -10,6 +10,8 @@ using Downloads: download
 using PrettyTables
 using TimerOutputs
 using DataFrames
+using PrecompileTools
+
 
 include("preferences.jl")
 include("countries.jl")
@@ -35,6 +37,15 @@ function __init__()
         @eval Main @everywhere using JuliaCon
     end
 end
+
+
+@compile_workload begin
+    JuliaCon.today()
+    JuliaCon.talksby("Carsten Bauer")
+end
+
+
+
 
 export juliacon2024
 

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -18,7 +18,7 @@ end
 
 const PRETALX_JSON_URL = "https://pretalx.com/juliacon2024/schedule/export/schedule.json"
 const DATA_ARCHIVE_JSON_URL = "https://raw.githubusercontent.com/JuliaCon/JuliaConDataArchive/master/juliacon2024_schedule/schedule.json"
-const jcon = Ref{DataFrame}()
+const jcon = Ref{Union{Nothing, DataFrame}}(nothing)
 
 function set_cachemode(mode::Symbol)
     @assert mode in (:DEFAULT, :NEVER, :ALWAYS)

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -151,7 +151,7 @@ Get the conference schedule as a DataFrame.
 On first call, the schedule is downloaded from Pretalx and cached for further usage.
 """
 function get_conference_schedule()
-    isassigned(jcon) || update_schedule()
+    isnothing(jcon[]) && update_schedule()
     return jcon[]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,9 +45,9 @@ using TimeZones
     end
 
     @testset "Schedule" begin
-        @test isnothing(JuliaCon.jcon)
+        @test isnothing(JuliaCon.jcon[])
         JuliaCon.update_schedule()
-        @test !isnothing(JuliaCon.jcon)
+        @test !isnothing(JuliaCon.jcon[])
 
         JuliaCon.debugmode()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,9 +45,9 @@ using TimeZones
     end
 
     @testset "Schedule" begin
-        @test !isassigned(JuliaCon.jcon)
+        @test isnothing(JuliaCon.jcon)
         JuliaCon.update_schedule()
-        @test isassigned(JuliaCon.jcon)
+        @test !isnothing(JuliaCon.jcon)
 
         JuliaCon.debugmode()
 


### PR DESCRIPTION
Hi,

I noticed some noticeable lag on the first TTFX. PrecompileTools improves this.

Before:

```julia
julia> @time (using JuliaCon; JuliaCon.talksby("Carsten Bauer"))

Tuesday 9 July 2024, 13:30 in TU-Eindhoven 0.244
        Hands-on with Julia for HPC on GPUs and CPUs (Workshop)
        ├─ Ludovic Räss, Carsten Bauer, Ivan Utkin et al.
        ├─ https://pretalx.com/juliacon2024/talk/NTQZJJ/
        └─ Accelerated & large-scale computing

(Shown times are in the following time zone: Europe/Zurich)
  3.181055 seconds (9.69 M allocations: 668.944 MiB, 5.24% gc time, 79.74% compilation time: <1% of which was recompilation)

```

After this:

```julia
julia> @time (using JuliaCon; JuliaCon.talksby("Carsten Bauer"))

Tuesday 9 July 2024, 13:30 in TU-Eindhoven 0.244
        Hands-on with Julia for HPC on GPUs and CPUs (Workshop)
        ├─ Ludovic Räss, Carsten Bauer, Ivan Utkin et al.
        ├─ https://pretalx.com/juliacon2024/talk/NTQZJJ/
        └─ Accelerated & large-scale computing

(Shown times are in the following time zone: Europe/Zurich)
  0.531413 seconds (697.91 k allocations: 50.078 MiB, 2.55% gc time, 5.40% compilation time: 46% of which was recompilation)
```


The first installation does some output, can we avoid that?

```julia
julia> @time (using JuliaCon; JuliaCon.talksby("Carsten Bauer"))
Precompiling JuliaCon
        Info Given JuliaCon was explicitly requested, output will be shown live 

Tuesday 9 July 2024, 13:30 in TU-Eindhoven 0.244
        Hands-on with Julia for HPC on GPUs and CPUs (Workshop)
        ├─ Ludovic Räss, Carsten Bauer, Ivan Utkin et al.
        ├─ https://pretalx.com/juliacon2024/talk/NTQZJJ/
        └─ Accelerated & large-scale computing

(Shown times are in the following time zone: Europe/Zurich)

[pid 620248] waiting for IO to finish:
 Handle type        uv_handle_t->data
 timer              0x381fc10->0x726da61f0160
This means that a package has started a background task or event source that has not finished running. For precompilation to complete successfully, the event source needs to be closed explicitly. See the developer documentation on fixing precompilation hangs for more help.

[pid 620248] waiting for IO to finish:
 Handle type        uv_handle_t->data
 timer              0x381fc10->0x726da61f0160
This means that a package has started a background task or event source that has not finished running. For precompilation to complete successfully, the event source needs to be closed explicitly. See the developer documentation on fixing precompilation hangs for more help.
  1 dependency successfully precompiled in 35 seconds. 35 already precompiled.
  1 dependency had output during precompilation:
┌ JuliaCon
│  [Output was shown above]
└  

Tuesday 9 July 2024, 13:30 in TU-Eindhoven 0.244
        Hands-on with Julia for HPC on GPUs and CPUs (Workshop)
        ├─ Ludovic Räss, Carsten Bauer, Ivan Utkin et al.
        ├─ https://pretalx.com/juliacon2024/talk/NTQZJJ/
        └─ Accelerated & large-scale computing

(Shown times are in the following time zone: Europe/Zurich)
 36.830595 seconds (4.64 M allocations: 347.131 MiB, 0.30% gc time, 5.13% compilation time: <1% of which was recompilation)

```

Best,

Felix