### PR TITLE
Make names with lowercase discoverable

### DIFF
--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -512,7 +512,7 @@ end
 function talksby(speaker::AbstractString)
     jcon = get_conference_schedule()
     df = filter(jcon; view=true) do talk
-        any(contains(s, speaker) for s in talk.speaker)
+        any(contains(lowercase(s), lowercase(speaker)) for s in talk.speaker)
     end
     _print_talks_list(df; bold_title=true, show_time=true)
 end


### PR DESCRIPTION
Hi,

Sometimes the names are lowercase, or at least I type it like that.

Should we apply those transformations everywhere? Or do we want to leave it like this?

Best,

Felix