### PR TITLE
Add `talksabout("something")` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ JuliaCon.talksby("Carsten Bauer")
 
 ![image](https://github.com/JuliaCon/JuliaCon.jl/assets/187980/e58c0281-ef1c-4ccd-93c3-8ce86e095622)
 
+## Search for talks by title
+```julia
+JuliaCon.talksabout("Optics")
+```
 
 ## T-Shirt code
 

--- a/src/JuliaCon.jl
+++ b/src/JuliaCon.jl
@@ -45,10 +45,11 @@ end
         JuliaCon.tomorrow()
         JuliaCon.now()
         JuliaCon.talksby("Carsten Bauer")
+        JuliaCon.talksabout("Optics")
         JuliaCon.jcon[] = nothing
     end
 end
 
-export juliacon2024, today, tomorrow, now, talksby
+export juliacon2024, today, tomorrow, now, talksby, talksabout
 
 end

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -516,3 +516,16 @@ function talksby(speaker::AbstractString)
     end
     _print_talks_list(df; bold_title=true, show_time=true)
 end
+
+"""
+    talksabout(title::AbstractString)
+
+Search for talks with titles containing the given `title` string.
+"""
+function talksabout(title::AbstractString)
+    jcon = get_conference_schedule()
+    df = filter(jcon; view=true) do talk
+        any(contains(lowercase(talk.title), lowercase(title)))
+    end
+    _print_talks_list(df; bold_title=true, show_time=true)
+end


### PR DESCRIPTION
As discussed in #38 


```julia
julia> JuliaCon.talksabout("causal")

Thursday 11 July 2024, 16:30 in Else (1.3)
        Causal Forecasting: How to disentangle causal effects (Talk)
        ├─ 
        ├─ https://pretalx.com/juliacon2024/talk/QZZQLF/
        └─ PyData

Thursday 11 July 2024, 14:00 in Method (1.5)
        Recursive Causal Discovery with Julia (Lightning Talk)
        ├─ Sepehr Elahi
        ├─ https://pretalx.com/juliacon2024/talk/FYFNAR/
        └─ General

Friday 12 July 2024, 11:00 in For Loop (3.2)
        Causal Machine Learning with CausalELM (Talk)
        ├─ Darren Colby
        ├─ https://pretalx.com/juliacon2024/talk/J9D8PL/
        └─ AI/ML/AD

(Shown times are in the following time zone: Europe/Berlin)

```